### PR TITLE
Use abstract type to constraint values of theme

### DIFF
--- a/src/App.re
+++ b/src/App.re
@@ -1,30 +1,9 @@
 /**
  * This file is the "platform" entrypoint. It defines the platform defaults for e.g. theme values.
  */
-let createTheme =
-    (
-      ~primaryColor=`hex("333333"),
-      ~brandColor=`hex("333333"),
-      ~textColor=`hex("000000"),
-      ~baseFontSize=`pt(10),
-      ~fontSizeSmall=`pt(9),
-      ~fontSizeLarge=`pt(13),
-      ~pageMargin=`mm(10.0),
-      ~footerHeight=`mm(20.0),
-      (),
-    ) => {
-  "primaryColor": primaryColor,
-  "brandColor": brandColor,
-  "textColor": textColor,
-  "baseFontSize": baseFontSize,
-  "fontSizeSmall": fontSizeSmall,
-  "fontSizeLarge": fontSizeLarge,
-  "pageMargin": pageMargin,
-  "footerHeight": footerHeight,
-};
 
-let defaultTheme = createTheme();
+let defaultTheme = Config.Theme.make();
 
-let start = (~theme: Config.theme) => {
+let start = (~theme: Config.Theme.t) => {
   ReactDOMRe.renderToElementWithId(<TestComponent theme />, "test");
 };

--- a/src/Config.re
+++ b/src/Config.re
@@ -6,14 +6,66 @@
  */
 open Css;
 
-type theme = {
-  .
-  "primaryColor": [ | `hex(string)],
-  "brandColor": [ | `hex(string)],
-  "textColor": [ | `hex(string)],
-  "baseFontSize": [ | `pt(int)],
-  "fontSizeSmall": [ | `pt(int)],
-  "fontSizeLarge": [ | `pt(int)],
-  "pageMargin": [ | `mm(float)],
-  "footerHeight": [ | `mm(float)],
+module Theme: {
+  // This is the type of a theme, it is abstract (opaque) and read-only
+  type t;
+
+  // The only way to create a theme is by using this make function,
+  // that controls how Color.t and Length.t instances are created
+  let make:
+    (
+      ~primaryColor: string=?,
+      ~brandColor: string=?,
+      ~textColor: string=?,
+      ~baseFontSize: int=?,
+      ~fontSizeSmall: int=?,
+      ~fontSizeLarge: int=?,
+      ~pageMargin: float=?,
+      ~footerHeight: float=?,
+      unit
+    ) =>
+    t;
+
+  // Getters for the theme variables
+  let primaryColor: t => Types.Color.t;
+  let textColor: t => Types.Color.t;
+  let fontSizeSmall: t => Types.Length.t;
+} = {
+  // All variables of a theme are atomic types of Css but their creation is constrained by the make function
+  type t = {
+    .
+    "primaryColor": Types.Color.t,
+    "brandColor": Types.Color.t,
+    "textColor": Types.Color.t,
+    "baseFontSize": Types.Length.t,
+    "fontSizeSmall": Types.Length.t,
+    "fontSizeLarge": Types.Length.t,
+    "pageMargin": Types.Length.t,
+    "footerHeight": Types.Length.t,
+  };
+
+  let make =
+      (
+        ~primaryColor="333333",
+        ~brandColor="333333",
+        ~textColor="000000",
+        ~baseFontSize=10,
+        ~fontSizeSmall=9,
+        ~fontSizeLarge=13,
+        ~pageMargin=10.0,
+        ~footerHeight=20.0,
+        (),
+      ) => {
+    "primaryColor": hex(primaryColor),
+    "brandColor": hex(brandColor),
+    "textColor": hex(textColor),
+    "baseFontSize": px(baseFontSize),
+    "fontSizeSmall": pt(fontSizeSmall),
+    "fontSizeLarge": pt(fontSizeLarge),
+    "pageMargin": mm(pageMargin),
+    "footerHeight": mm(footerHeight),
+  };
+  let primaryColor = theme => theme##primaryColor;
+  let textColor = theme => theme##textColor;
+  let fontSizeSmall = theme => theme##fontSizeSmall;
 };

--- a/src/Index.re
+++ b/src/Index.re
@@ -6,6 +6,6 @@
  * This file only defines minimal overrides and then calls for platform code.
  */
 // Theme
-let theme = App.createTheme(~textColor=`hex("202020"), ());
+let theme = Config.Theme.make(~textColor="202020", ());
 
 App.start(~theme);

--- a/src/TestComponent.re
+++ b/src/TestComponent.re
@@ -1,10 +1,9 @@
 open Css;
 
 module Styles = {
-  let getCard = theme =>
-    style([color(theme##textColor), fontSize(theme##fontSizeSmall)]);
+  open Config.Theme;
+  let getCard = theme => style([color(theme->textColor), fontSize(theme->fontSizeSmall)]);
 };
 
 [@react.component]
-let make = (~theme: Config.theme) =>
-  <div className={Styles.getCard(theme)}> {React.string("Testing")} </div>;
+let make = (~theme: Config.Theme.t) => <div className={Styles.getCard(theme)}> {React.string("Testing")} </div>;


### PR DESCRIPTION
Hi, 
I'm creating a pull request on your demo project to continue the discussion.

I think the problem is that you're trying to create a constraint at the wrong level. 
You want to create a subset of the type to limit the possibilities given to a user to instanciate the theme variable. For that purpose, you create a new polymorphic variant type `[ | 'hex(string) ]`  that contains only one variant 🤔 ! 

But, by doing so you are creating a new type that is totally different than the `Css.Type.Color.t` type. 
Although, what you want is a variable of type `Color.t`, no matter how you create the value, at the end you'll get a color (or a length for the other ones). a `hex("FFF")`or a `rgb(1,2,3)` are both colors.

So, really, what the theme variable should be is a `Color.t`, not a new incompatible type.

What I think is needed is a way to constraint how the user initialise the value, but not a constraint on the value type. 

The pull request is how I would code it.

The idea is that you can't have a concrete type for the theme, it must be an abstract type because this is the only way you can totally control how the values are created (or at least the only way I know 😄  ).

And you can't use 'hex or 'pt in the constructor, you can only pass values because you want to control the type of the value (instead of `~textColor='hex("202020")` you use `~textColor="202020"`, and that makes sense).

wdyt?